### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -25,7 +25,7 @@ plugins:
 provider:
   name: aws
   state: dev
-  runtime: nodejs10.x
+  runtime: nodejs14.x
   region: us-east-1
 
 # you can add statements to the Lambda function's IAM Role here


### PR DESCRIPTION
CloudFormation templates in aws-alexa-workshop-smarthome have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.